### PR TITLE
Fix: bad merge conflict

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,14 +11,6 @@ concurrency:
 jobs:
   publish_image:
     name: Publish Docker image
-<<<<<<< HEAD
-    uses: './.github/workflows/publish-image.yml'
-    secrets: inherit
-    with:
-      # NOTE: by default the image will be built with type=ref,event=tag; so we don't need to specify it here
-      tags: |
-        type=raw,value=e2e
-=======
     runs-on: ubuntu-latest
     outputs:
       shortSha: ${{ steps.output-step.outputs.short-sha }}
@@ -67,7 +59,6 @@ jobs:
           build-args: |
             GIT_COMMIT_SHA=${{ env.SHORT_SHA }}
             GIT_TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
->>>>>>> subspace-frontend
 
   deploy_e2e:
     name: Deploy E2E instance


### PR DESCRIPTION
## Fix: bad merge conflict

This pull request includes changes to the `.github/workflows/e2e-tests.yml` file, specifically focused on the `publish_image` job and its configuration.

Here are the most important changes:

* Removed the `uses` directive and related configuration in the `publish_image` job, which previously pointed to `./.github/workflows/publish-image.yml` and included secrets and build tags.
* Adjusted the `runs-on` directive to use `ubuntu-latest` for the `publish_image` job.
* Corrected a merge conflict marker (`->>>>>>> subspace-frontend`) in the `jobs` section.